### PR TITLE
Added some dependencies to requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,5 @@ numpy>=1.19.4
 numba>=0.52.0
 torch>=1.6.0
 scipy>=1.6.0
+configparser
+requests>=2.21.0,<3


### PR DESCRIPTION
When creating a fresh conda enviroment and installing pip on it (conda install pip) and then running ~/path-to-conda/envs/<env-name>/bin/pip install -r requirements.txt some errors show up:

For requests:
ERROR: pip's dependency resolver does not currently take into account all the packages that are installed. This behaviour is the source of the following dependency conflicts.
tensorboard 2.8.0 requires requests<3,>=2.21.0, which is not installed.

For configparser:
ERROR: pip's dependency resolver does not currently take into account all the packages that are installed. This behaviour is the source of the following dependency conflicts.
webdriver-manager 3.5.2 requires configparser, which is not installed.

Adding those packages to requiremens should solve the issue