### PR TITLE
Standard installation command

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,9 +76,9 @@ git clone https://github.com/kiharalab/DAQ && cd DAQ
 ##### 3.1 [`install conda`](https://bit.ly/daq-score).
 ##### 3.2 Install dependency in command line
 ```
-conda create -n daq python=3.10 gcc gxx -c conda-forge
-conda activate daq
 ./install.sh
+or
+./install.sh <my-daq-env-name> (if you want to specify your own name for the conda environment)
 ```
 * This version of PyTorch supports a wider range of GPUs. We tested the following generations of NVIDIA GPUs:
   * Pascal (GTX 1080)

--- a/README.md
+++ b/README.md
@@ -78,8 +78,7 @@ git clone https://github.com/kiharalab/DAQ && cd DAQ
 ```
 conda create -n daq python=3.10 gcc gxx -c conda-forge
 conda activate daq
-pip3 install -r requirements.txt
-pip3 install torch==2.6.0 torchvision torchaudio --index-url https://download.pytorch.org/whl/cu118
+./install.sh
 ```
 * This version of PyTorch supports a wider range of GPUs. We tested the following generations of NVIDIA GPUs:
   * Pascal (GTX 1080)

--- a/README.md
+++ b/README.md
@@ -77,8 +77,10 @@ git clone https://github.com/kiharalab/DAQ && cd DAQ
 ##### 3.2 Install dependency in command line
 ```
 ./install.sh
-or
-./install.sh <my-daq-env-name> (if you want to specify your own name for the conda environment)
+```
+or, if you want to specify a custom conda environment name:
+```
+./install.sh <my-custom-daq-env-name>
 ```
 * This version of PyTorch supports a wider range of GPUs. We tested the following generations of NVIDIA GPUs:
   * Pascal (GTX 1080)
@@ -93,6 +95,7 @@ Each time when you want to run my code, simply activate the environment by
 conda activate daq
 conda deactivate(If you want to exit)
 ```
+**Note:** If you created a conda environment with a custom name, you will need to run `conda activate <your-custom-name>` instead of the command shown above.
 
 ## Usage
 ```

--- a/install.sh
+++ b/install.sh
@@ -1,3 +1,8 @@
 #!/bin/bash
 
+ENV_NAME=${1:-daq}
+
+conda create -n "$ENV_NAME" python=3.10 gcc gxx -c conda-forge -y
+conda activate "$ENV_NAME"
+
 pip3 install -r requirements.txt -r torch-requirements.txt

--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+pip3 install -r requirements.txt -r torch-requirements.txt

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,4 +4,3 @@ numba>=0.52.0
 scipy>=1.6.0
 configparser
 requests>=2.21.0,<3
-# torch==1.12.1

--- a/torch-requirements.txt
+++ b/torch-requirements.txt
@@ -1,0 +1,4 @@
+--index-url https://download.pytorch.org/whl/cu118
+torch==2.6.0
+torchvision
+torchaudio


### PR DESCRIPTION
This Pull Request aims to create a standard command for the installation of DAQ.

## Why is this needed?
DAQ is not only installed and run manually by users, but also some frameworks, as Scipion, in the plugin [scipion-em-kiharalab](https://github.com/scipion-em/scipion-em-kiharalab), which means that the installation is done automatically by the framework.
This means that, whenever the installation commands change in this repository, the installation process in the framework breaks and needs an update.

## How is it fixed?
This Pull Request solves this issue by using the `install.sh` bash script, which will contain all the installation commands needed. When, inevitably, an installation change is made (for example, an update in the index url for torch packages after a version bump), the installation command for the external user/framework will still be the same, as the change will only take place inside the `install.sh` file. This file allows to send a custom environment name as a parameter, or use the default name `daq` if no parameters are used.

## Sumary of improvements:
1. Added `install.sh` to simplify installation process for users.
2. Added `torch-requirements.txt` to contain all torch related dependencies with their required index url.
3. Updated `README.md` to reflect installation changes.